### PR TITLE
Forward errors to clones (fixes #1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "inherits": "^2.0.1",
-    "pump": "^1.0.1",
     "process-nextick-args": "^1.0.6",
     "through2": "^2.0.1"
   }


### PR DESCRIPTION
Implements:

1. Clone is destroyed or errors -> nothing happens to the other clones, or the Cloneable
2. Cloneable (or the cloned) errors -> all clones error
3. Cloneable (or the cloned) is destroyed -> all clones are destroyed

Except for:

> All clones are destroyed -> the Cloneable gets destroyed as well

 @mcollina what's your reasoning? If the clones are destroyed, shouldn't the cloneable remain readable itself?