### PR TITLE
Backport fix from #19 to 1.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ function forwardDestroy (src, dest) {
   src.on('close', onClose)
 
   function destroy (err) {
+    src.removeListener('close', onClose)
     dest.destroy(err)
   }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "flush-write-stream": "^1.0.0",
     "from2": "^2.1.1",
     "pre-commit": "^1.1.2",
+    "pump": "^3.0.0",
     "readable-stream": "^2.3.5",
     "standard": "^11.0.0",
     "tap-spec": "^4.1.1",

--- a/test.js
+++ b/test.js
@@ -6,6 +6,7 @@ var test = require('tape').test
 var from = require('from2')
 var crypto = require('crypto')
 var sink = require('flush-write-stream')
+var pump = require('pump')
 var cloneable = require('./')
 
 test('basic passthrough', function (t) {
@@ -681,4 +682,21 @@ test('big file', function (t) {
 
   // Pipe a long time after
   setTimeout(pipe.bind(null, stream.clone(), 2), 1000)
+})
+
+test('pump error', function (t) {
+  t.plan(1)
+
+  var err = new Error('kaboom')
+
+  pump([
+    cloneable(from(function () {
+      this.destroy(err)
+    })),
+    sink(function (chunk, enc, cb) {
+      t.fail('this should not be called')
+    })
+  ], function (_err) {
+    t.equal(_err, err)
+  })
 })


### PR DESCRIPTION
@mcollina here's the backport to 1.x - I submitted it against master but it's probably best to just pull into a branch.

I used `pump` to replace `stream.pipeline` in the tests and used `from2` because the destroy stuff was weird in the old ReadableStream.

Thanks for accepting this backport! 🍻